### PR TITLE
Invoke isEnabled

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.1.internal/src/io/openliberty/microprofile/telemetry11/internal/rest/javax/TelemetryJaxRsProviderRegister.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.1.internal/src/io/openliberty/microprofile/telemetry11/internal/rest/javax/TelemetryJaxRsProviderRegister.java
@@ -38,7 +38,7 @@ public class TelemetryJaxRsProviderRegister implements JaxRsProviderRegister {
         try {
             if (clientSide) {
                 TelemetryClientFilter currentFilter = new TelemetryClientFilter();
-                if (currentFilter != null) {
+                if (currentFilter != null && currentFilter.isEnabled()) {
                     providers.add(currentFilter);
                 }
             }


### PR DESCRIPTION
Use isEnabled to not add anything when telemetry is disabled, and produce the logging the test requires. 